### PR TITLE
fix: use correct lighting data for blocks with emissive lighting.

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/model/light/data/LightDataAccess.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/model/light/data/LightDataAccess.java
@@ -73,9 +73,11 @@ public abstract class LightDataAccess {
         // solve lighting issues underwater.
         boolean op = state.getFluidState() != EMPTY_FLUID_STATE || state.getOpacity(world, pos) == 0;
         boolean fo = state.isOpaqueFullCube(world, pos);
+        boolean em = state.hasEmissiveLighting(world, pos);
 
-        // OPTIMIZE: Do not calculate lightmap data if the block is full and opaque
-        int lm = fo ? 0 : WorldRenderer.getLightmapCoordinates(world, state, pos);
+        // OPTIMIZE: Do not calculate lightmap data if the block is full and opaque.
+        // FIX: Calculate lightmap data for emissive blocks (currently only magma), even though they are full and opaque.
+        int lm = (fo && !em) ? 0 : WorldRenderer.getLightmapCoordinates(world, state, pos);
 
         return packAO(ao) | packLM(lm) | packOP(op) | packFO(fo) | (1L << 60);
     }

--- a/src/main/java/me/jellysquid/mods/sodium/client/model/light/flat/FlatLightPipeline.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/model/light/flat/FlatLightPipeline.java
@@ -29,7 +29,7 @@ public class FlatLightPipeline implements LightPipeline {
     @Override
     public void calculate(ModelQuadView quad, BlockPos pos, QuadLightData out, Direction face, boolean shade) {
         // If the face is aligned, use the light data above it
-        if ((quad.getFlags() & ModelQuadFlags.IS_ALIGNED) != 0) {
+        if ((quad.getFlags() & ModelQuadFlags.IS_ALIGNED) != 0 && !this.lightCache.getWorld().getBlockState(pos).hasEmissiveLighting(this.lightCache.getWorld(), pos)) {
             Arrays.fill(out.lm, unpackLM(this.lightCache.get(pos, face)));
         } else {
             Arrays.fill(out.lm, unpackLM(this.lightCache.get(pos)));


### PR DESCRIPTION
Fixes #184. Updates LightDataAccess and FlatLightPipeline to stop ignoring whether or not a block has emissive lighting (currently only MAGMA_BLOCK).